### PR TITLE
Add deprecation and availability annotations to SpringBoard headers.

### DIFF
--- a/SpringBoard/SBApplication.h
+++ b/SpringBoard/SBApplication.h
@@ -2,9 +2,9 @@ static NSString *const kSBAppTagsHidden = @"hidden";
 
 @interface SBApplication : NSObject
 
-@property (nonatomic, retain, readonly) NSString *bundleIdentifier;
+@property (nonatomic, retain, readonly) NSString *bundleIdentifier NS_AVAILABLE_IOS(8_0); // Technically available in iOS 5 as well (https://github.com/MP0w/iOS-Headers/blob/master/iOS5.0/SpringBoard/SBApplication.h#L143) and even iOS 4, but you probably don't want to use that (see: Camera/Photos).
 @property (nonatomic, retain, readonly) NSString *displayName;
-@property (nonatomic, retain, readonly) NSString *displayIdentifier; // removed in 8.0
+@property (nonatomic, retain, readonly) NSString *displayIdentifier NS_DEPRECATED_IOS(4_0, 8_0);
 
 @property (nonatomic, retain, readonly) NSString *sandboxPath;
 @property (nonatomic, retain, readonly) NSString *bundleContainerPath;

--- a/SpringBoard/SBBannerView.h
+++ b/SpringBoard/SBBannerView.h
@@ -1,5 +1,3 @@
-// 5.x only
-
-@interface SBBannerView : UIView
+NS_CLASS_DEPRECATED_IOS(5_0, 6_0) @interface SBBannerView : UIView
 
 @end

--- a/SpringBoard/SBBulletinBannerController.h
+++ b/SpringBoard/SBBulletinBannerController.h
@@ -4,9 +4,9 @@
 
 + (instancetype)sharedInstance;
 
-- (void)observer:(BBObserver *)observer addBulletin:(BBBulletin *)bulletin forFeed:(NSUInteger)feed; // 7.0 - 8.1
-- (void)observer:(BBObserver *)observer addBulletin:(BBBulletin *)bulletin forFeed:(NSUInteger)feed playLightsAndSirens:(BOOL)playLightsAndSirens withReply:(id)reply; // 8.2 -
+- (void)observer:(BBObserver *)observer addBulletin:(BBBulletin *)bulletin forFeed:(NSUInteger)feed NS_DEPRECATED_IOS(7_0, 8_1);
+- (void)observer:(BBObserver *)observer addBulletin:(BBBulletin *)bulletin forFeed:(NSUInteger)feed playLightsAndSirens:(BOOL)playLightsAndSirens withReply:(id)reply NS_AVAILABLE_IOS(8_2);
 
-- (void)showTestBanner; // 5.0 - 6.1
+- (void)showTestBanner NS_DEPRECATED_IOS(5_0, 6_1);
 
 @end

--- a/SpringBoard/SBBulletinBannerController.h
+++ b/SpringBoard/SBBulletinBannerController.h
@@ -1,4 +1,4 @@
-@class BBObserver, BBBulletinRequest;
+@class BBObserver, BBBulletinRequest, BBBulletin;
 
 @interface SBBulletinBannerController : NSObject
 

--- a/SpringBoard/SBBulletinBannerView.h
+++ b/SpringBoard/SBBulletinBannerView.h
@@ -1,7 +1,8 @@
-// 6.0+ only
-
 #import "SBBannerView.h"
 
-@interface SBBulletinBannerView : SBBannerView
+@interface SBUIRoundedBannerItemView : UIView // iOS 6 only, but the compiler doesn't need to know that yet.
+@end
+
+NS_CLASS_AVAILABLE_IOS(6_0) @interface SBBulletinBannerView : SBUIRoundedBannerItemView
 
 @end

--- a/SpringBoard/SBIconModel.h
+++ b/SpringBoard/SBIconModel.h
@@ -2,6 +2,7 @@
 
 @interface SBIconModel : NSObject
 
-- (SBApplicationIcon *)applicationIconForBundleIdentifier:(NSString *)bundleID;
+- (SBApplicationIcon *)applicationIconForBundleIdentifier:(NSString *)bundleID NS_AVAILABLE_IOS(8_0);
+- (SBApplicationIcon *)applicationIconForDisplayIdentifier:(NSString *)displayIdentifier NS_DEPRECATED_IOS(4_0, 8_0);
 
 @end


### PR DESCRIPTION
This only adds these annotations to headers which had already been marked with availability notes in comments (and `SBApplication` and `SBIconModel`, which I looked up and annotated myself).