### PR TITLE
Remove NSLog deprecation macro

### DIFF
--- a/_Prefix/HBLog.h
+++ b/_Prefix/HBLog.h
@@ -1,10 +1,5 @@
 #include <CoreFoundation/CFLogUtilities.h>
 
-#define NSLog(...) { \
-	_Pragma("message(\"NSLog is deprecated. Try HBLogDebug, HBLogInfo, and HBLogError.\")"); \
-	NSLog(__VA_ARGS__); \
-}
-
 #ifdef __DEBUG__
 	#define HB_LOG_FORMAT(color) CFSTR("\e[1;3" #color "m[%s] \e[m\e[0;3" #color "m%s:%d\e[m \e[0;30;4" #color "m%s:\e[m %@")
 #else


### PR DESCRIPTION
The NSLog macro in `_Prefix/HBLog.h` causes issues for those who have NSLog macros of their own in their projects. It's a rather noticeable usability issue, and should be removed.

This functionality can be re-added later as a part of [`kirb/theos`](https://github.com/kirb/theos) instead.