### PR TITLE
Add missing PSSpinnerCell to PSCellType enum

### DIFF
--- a/Preferences/PSTableCell.h
+++ b/Preferences/PSTableCell.h
@@ -17,7 +17,8 @@ typedef NS_ENUM(NSInteger, PSCellType) {
 	PSGiantCell,
 	PSSecureEditTextCell,
 	PSButtonCell,
-	PSEditTextViewCell
+	PSEditTextViewCell,
+	PSSpinnerCell
 };
 
 @interface PSTableCell : UITableViewCell


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds PSSpinnerCell to the PSCellType enum

Info available on [The Apple Wiki](https://theapplewiki.com/wiki/Dev:Preferences_specifier_plist#PSSpinnerCell)

Confirmed to still function/exist on modern iOS

Checklist
---------
- [- ] New code follows the [code rules](https://github.com/theos/headers/blob/master/README.md#code-rules)
- [- ] I've added modulemaps for any new libraries (e.g. see [libactivator/module.modulemap](https://github.com/theos/headers/blob/f3e596d896bae8f07c43cfb00ef55bf6224b4cdc/libactivator/module.modulemap)): it should be possible to `@import MyLibrary;` in ObjC, or `import MyLibrary` in Swift.
- [- ] My contribution is code written by myself from reverse-engineered headers, licensed into the Public Domain as per [LICENSE.md](LICENSE.md); or, code written by myself / taken from an existing project, released under an OSI-approved license, and I've added relevant licensing credit to [LICENSE.md](LICENSE.md)


Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
n/a

Any other comments?
-------------------
justice for PSSpinnerCell

Where has this been tested?
---------------------------
**Operating System:** iOS 15.1, iOS 16.2

**Platform:** WSL2

**Target Platform:** iOS

**Toolchain Version:** …

**SDK Version:** …
